### PR TITLE
nc: fix proxy authentication required detection for HTTP/1.1

### DIFF
--- a/usr.bin/nc/socks.c
+++ b/usr.bin/nc/socks.c
@@ -373,7 +373,8 @@ socks_connect(const char *host, const char *port,
 		/* Read status reply */
 		proxy_read_line(proxyfd, buf, sizeof(buf));
 		if (proxyuser != NULL &&
-		    strncmp(buf, "HTTP/1.0 407 ", 12) == 0) {
+		    (strncmp(buf, "HTTP/1.0 407 ", 12) == 0 ||
+		     strncmp(buf, "HTTP/1.1 407 ", 12) == 0)) {
 			if (authretry > 1) {
 				fprintf(stderr, "Proxy authentication "
 				    "failed\n");


### PR DESCRIPTION
This is regarding **nc**'s proxy capability.
I've been facing an issue where as per the man-page of _nc_ it should work, but effectively didn't.

In my case, I launched the following and was expecting nc is asking for Proxy password.
Instead the following happened:
```
$ nc -x192.168.80.80:8080 -Xconnect -Pproxyuser $destination 80
nc: Proxy error: "HTTP/1.1 407 Proxy Authentication Required"
```
A little research of the source code comparing a traffic catpure revealed the problem.
Our proxy is responding with the string `HTTP/1.1 407 Proxy Authentication Required\r\n`
But asking for password is only approached if the string starts with _HTTP/1.**0** 407_.

This pull-request addresses the Proxy Password support also for HTTP/1.1 aware HTTP proxies.