### PR TITLE
zstd compression for SSH (INCOMPLETE)

### DIFF
--- a/usr.bin/ssh/kex.c
+++ b/usr.bin/ssh/kex.c
@@ -785,6 +785,9 @@ choose_comp(struct sshcomp *comp, char *client, char *server)
 		return SSH_ERR_NO_COMPRESS_ALG_MATCH;
 	if (strcmp(name, "zlib@openssh.com") == 0) {
 		comp->type = COMP_DELAYED;
+#warning EXPERIMENTAL ZSTD SUPPORT
+	} else if (strcmp(name, "zstd@openssh.com") == 0) {
+		comp->type = COMP_ZSTD_DELAYED;
 	} else if (strcmp(name, "zlib") == 0) {
 		comp->type = COMP_ZLIB;
 	} else if (strcmp(name, "none") == 0) {

--- a/usr.bin/ssh/kex.h
+++ b/usr.bin/ssh/kex.h
@@ -61,6 +61,7 @@
 /* pre-auth compression (COMP_ZLIB) is only supported in the client */
 #define COMP_ZLIB	1
 #define COMP_DELAYED	2
+#define COMP_ZSTD_DELAYED	3
 
 #define CURVE25519_SIZE 32
 

--- a/usr.bin/ssh/myproposal.h
+++ b/usr.bin/ssh/myproposal.h
@@ -137,7 +137,7 @@
 
 #endif /* WITH_OPENSSL */
 
-#define	KEX_DEFAULT_COMP	"none,zlib@openssh.com"
+#define	KEX_DEFAULT_COMP	"none,zstd@openssh.com,zlib@openssh.com"
 #define	KEX_DEFAULT_LANG	""
 
 #define KEX_CLIENT \

--- a/usr.bin/ssh/sshconnect2.c
+++ b/usr.bin/ssh/sshconnect2.c
@@ -168,7 +168,8 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
 	    compat_cipher_proposal(options.ciphers);
 	myproposal[PROPOSAL_COMP_ALGS_CTOS] =
 	    myproposal[PROPOSAL_COMP_ALGS_STOC] = options.compression ?
-	    "zlib@openssh.com,zlib,none" : "none,zlib@openssh.com,zlib";
+	    "zstd@openssh.com,zlib@openssh.com,zlib,none" :
+        "none,zstd@openssh.com,zlib@openssh.com,zlib";
 	myproposal[PROPOSAL_MAC_ALGS_CTOS] =
 	    myproposal[PROPOSAL_MAC_ALGS_STOC] = options.macs;
 	if (options.hostkeyalgorithms != NULL) {


### PR DESCRIPTION
This is not a pull request; planning to close. I know. tech@. This is just here for discussion.

The zstd library (BSD licensed) would need to be added in /usr/lib and
appropriately hooked in to the build system; not being an OpenBSD user directly, I haven't looking into how to do that.

This enables dynamic compression with the zstd compression library as the default (first choice) compression, but retains (or at least intends to, definitely alpha-level here) interoperability with old endpoints. It attempts to increase compression quality when SSH cpu utilization is above 85%, and decrease quality (increase speed) when SSH utilization is above 99%. On modern multi-CPU systems, this can be a big win for performance on high-bandwidth connections, and can outperform zlib for compression on low-bandwidth connections.