### PR TITLE
add TRACEPOINT to check tick increment.

### DIFF
--- a/sys/arch/amd64/amd64/softintr.c
+++ b/sys/arch/amd64/amd64/softintr.c
@@ -41,6 +41,8 @@
 
 #include <uvm/uvm_extern.h>
 
+#include <sys/tracepoint.h>
+
 struct x86_soft_intr x86_soft_intrs[X86_NSOFTINTR];
 
 const int x86_soft_intr_to_ssir[X86_NSOFTINTR] = {
@@ -60,6 +62,7 @@ softintr_init(void)
 	struct x86_soft_intr *si;
 	int i;
 
+	TRACEPOINT(softintr, init, NULL);
 	for (i = 0; i < X86_NSOFTINTR; i++) {
 		si = &x86_soft_intrs[i];
 		TAILQ_INIT(&si->softintr_q);
@@ -80,6 +83,8 @@ softintr_dispatch(int which)
 	struct x86_soft_intr *si = &x86_soft_intrs[which];
 	struct x86_soft_intrhand *sih;
 	int floor;
+
+	TRACEPOINT(softintr, dispatch, which);
 
 	floor = ci->ci_handled_intr_level;
 	ci->ci_handled_intr_level = ci->ci_ilevel;
@@ -117,6 +122,8 @@ softintr_establish(int ipl, void (*func)(void *), void *arg)
 	struct x86_soft_intr *si;
 	struct x86_soft_intrhand *sih;
 	int which;
+
+	TRACEPOINT(softintr, establish, ipl);
 
 	switch (ipl) {
 	case IPL_SOFTCLOCK:
@@ -158,6 +165,8 @@ softintr_disestablish(void *arg)
 {
 	struct x86_soft_intrhand *sih = arg;
 	struct x86_soft_intr *si = sih->sih_intrhead;
+
+	TRACEPOINT(softintr, disestablish, arg);
 
 	mtx_enter(&si->softintr_lock);
 	if (sih->sih_pending) {

--- a/sys/conf/GENERIC
+++ b/sys/conf/GENERIC
@@ -82,7 +82,7 @@ pseudo-device	msts	1	# MSTS line discipline
 pseudo-device	endrun	1	# EndRun line discipline
 pseudo-device	vnd	4	# vnode disk devices
 pseudo-device	ksyms	1	# kernel symbols device
-#pseudo-device	dt		# Dynamic Tracer
+pseudo-device	dt		# Dynamic Tracer
 
 # clonable devices
 pseudo-device	bpfilter	# packet filter

--- a/sys/dev/dt/dt_prov_static.c
+++ b/sys/dev/dt/dt_prov_static.c
@@ -43,6 +43,11 @@ DT_STATIC_PROBE0(sched, on__cpu);
 DT_STATIC_PROBE0(sched, remain__cpu);
 DT_STATIC_PROBE0(sched, sleep);
 DT_STATIC_PROBE0(sched, wakeup);
+DT_STATIC_PROBE0(softintr, init);
+DT_STATIC_PROBE1(softintr, dispatch, "int");
+DT_STATIC_PROBE1(softintr, establish, "int");
+DT_STATIC_PROBE1(softintr, disestablish, "void *");
+DT_STATIC_PROBE0(clock, hardclock);
 
 /*
  * Raw syscalls
@@ -65,6 +70,11 @@ struct dt_probe *dtps_static[] = {
 	/* Raw syscalls */
 	&_DT_STATIC_P(raw_syscalls, sys_enter),
 	&_DT_STATIC_P(raw_syscalls, sys_exit),
+	&_DT_STATIC_P(softintr, init),
+	&_DT_STATIC_P(softintr, dispatch),
+	&_DT_STATIC_P(softintr, establish),
+	&_DT_STATIC_P(softintr, disestablish),
+	&_DT_STATIC_P(clock, hardclock),
 };
 
 int

--- a/sys/kern/kern_clock.c
+++ b/sys/kern/kern_clock.c
@@ -60,6 +60,8 @@
 #include <dev/dt/dtvar.h>
 #endif
 
+#include <sys/tracepoint.h>
+
 /*
  * Clock handling routines.
  *
@@ -186,6 +188,7 @@ hardclock(struct clockframe *frame)
 	if (CPU_IS_PRIMARY(ci) == 0)
 		return;
 
+	TRACEPOINT(clock, hardclock, NULL);
 	tc_ticktock();
 	ticks++;
 	jiffies++;


### PR DESCRIPTION
***Do NOT merge this branch***

This branch is used for checking tick count up.
I'm doubting following scenario.

1. OpenBSD is a guest of Virtual Machine.
2. Virtual CPUs are overcommitted.
3. Cpus have heavy load.
4. Hypervisor doesn't assign CPU to OpenBSD.
5. Tick count delays.

To see this would happen, run following btrace script.
Check `usec/count`.

```
BEGIN {
  time("%F %T\n");
  @begin = nsecs;
  @c = 0;
}

tracepoint:clock:hardclock
{
  @c = @c + 1;
}

END {
  @end = nsecs;

  @past = (@end - @begin)/1000;
  printf("past time: %d usec\n", @past);
  printf("count: %d\n", @c);
  printf("average: %d usec/count\n", @past / @c );
  time("%F %T\n");
}
```